### PR TITLE
Adjust prompt options when using function calls

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -44,7 +44,13 @@ export async function ensureModel(
     const ctx = await model.createContext({ contextSize: opts.contextSize });
     try {
       const session = new LlamaChatSession({ contextSequence: ctx.getSequence() });
-      const res = await session.prompt(prompt, o.functions);
+      const { functions, stop, ...generationOpts } = o;
+      const promptOptions = {
+        ...generationOpts,
+        ...(stop ? { customStopTriggers: stop } : {}),
+        ...(functions ? { functions, documentFunctionParams: false } : {}),
+      };
+      const res = await session.prompt(prompt, promptOptions);
       return res.trim();
     } finally {
       await ctx.dispose();


### PR DESCRIPTION
## Summary
- set LlamaChatSession prompt options to include existing generation settings
- disable function parameter documentation when functions are provided to skip verbose docs

## Testing
- npm run build
- node dist/cli.js ./fake-model.gguf . --agent --context 512 --dry-run *(fails: no model file present)*

------
https://chatgpt.com/codex/tasks/task_e_68db00c933e4832880671b96a851a3b7