### PR TITLE
Disable function param docs when tool calling

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -57,7 +57,10 @@ export async function ensureModel(
       if (typeof o.maxTokens === 'number') promptOptions.maxTokens = o.maxTokens;
       if (typeof o.temperature === 'number') promptOptions.temperature = o.temperature;
       if (o.stop && o.stop.length) promptOptions.customStopTriggers = o.stop;
-      if (o.functions) promptOptions.functions = o.functions;
+      if (o.functions) {
+        promptOptions.functions = o.functions;
+        promptOptions.documentFunctionParams = false;
+      }
       const res = await session.prompt(prompt, promptOptions);
       return res.trim();
     } finally {

--- a/src/types/picocolors.d.ts
+++ b/src/types/picocolors.d.ts
@@ -1,0 +1,1 @@
+declare module 'picocolors';


### PR DESCRIPTION
## Summary
- ensure chat completions disable function parameter documentation when tool calling to keep prompts compact
- add a minimal type declaration for picocolors so the TypeScript build can succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db0339142083288c0d19fcfb6673bb