### PR TITLE
Improve CLI progress summary readability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,7 +96,13 @@ program
     let statusLine = opts.agent ? '🛠️  Preparing…' : '';
 
     const updateOverall = () => {
-      const summary = `✍️  ${modeLabel} ${pc.green(`✅  ${written}`)} • ${pc.magenta(`⏭️  ${skippedCount}`)} • ${pc.yellow(`📄  exists ${exists}`)}`;
+      const summaryLines = [
+        `✍️  ${modeLabel}`,
+        `   ${pc.green(`✅  Wrote: ${written}`)}`,
+        `   ${pc.magenta(`⏭️  Skipped: ${skippedCount}`)}`,
+        `   ${pc.yellow(`📄  Already existed: ${exists}`)}`,
+      ];
+      const summary = summaryLines.join('\n');
       overall.text = statusLine ? `${summary}\n${statusLine}` : summary;
       overall.render();
     };


### PR DESCRIPTION
## Summary
- enhance the CLI overall progress summary with multi-line wording for each metric

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db083a7bb88328a796775a3209d020