### PR TITLE
Add verbose mode and configure agent tool call limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # llama-testgen
 
-Generate focused unit tests for React/React Native TypeScript projects using local GGUF models via **node-llama-cpp**.
+Generate focused unit tests for React/React Native TypeScript projects using local or remote models via **node-llama-cpp**.
 
 ## Install
 ```bash
@@ -8,11 +8,11 @@ pnpm i
 pnpm build
 ```
 
-> You need a local or remote GGUF model compatible with node-llama-cpp. Example: code-specialized 7B–14B models (Q6_K/Q8_0 recommended).
+> You need a local or remote model compatible with node-llama-cpp (GGUF files are common, but not required). Example: code-specialized 7B–14B models (Q6_K/Q8_0 recommended).
 
 ## Usage
 ```bash
-llama-testgen <modelPathOrUrlOrHF> <projectPath> [options]
+llama-testgen <modelPathOrUrl> <projectPath> [options]
 ```
 
 **Examples**
@@ -31,10 +31,11 @@ llama-testgen hf:mradermacher/Qwen3-Coder-30B-A3B-Instruct-480B-Distill-V2-Fp32-
 - `--include <globs...>` / `--exclude <globs...>`: Glob filters
 - `--force`: Overwrite existing tests
 - `--dry-run`: Only print plan
-- `--debug`: Verbose logs
+- `-v, --verbose`: Verbose logs (`--debug` remains as an alias)
 - `--context <n>`: Request model context size (tokens)
 - `--fast`: Future preset for faster runs
 - `--agent`: **Tool-calling two-pass** (plan → tests)
+- `--max-tool-calls <n>`: Cap agent tool invocations per chunk (default 40)
 - Output directory is cleared on each run (skipped for `--dry-run`).
 
 ## How it works

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ const program = new Command();
 program
   .name('llama-testgen')
   .description('🧪  Generate unit tests for React/React Native TypeScript projects using node-llama-cpp')
-  .argument('<model>', 'Model id or GGUF URL/path (e.g. ./models/qwen2.5-coder.Q8.gguf or https://... .gguf)')
+  .argument('<model>', 'Model id or path/URL (GGUF, Hugging Face alias, etc.)')
   .argument('<projectPath>', 'Path to the project root')
   .option('-o, --out <dir>', 'Output directory for tests (default: autodetect __tests__ or __generated-tests__)', '')
   .option('--max-files <n>', 'Limit number of files to process', (v)=>parseInt(v,10))
@@ -48,14 +48,21 @@ program
   .option('--include <globs...>', 'Only include files matching these globs (default: src/**/*.{ts,tsx,js,jsx})')
   .option('--exclude <globs...>', 'Exclude files matching these globs')
   .option('--force', 'Overwrite existing test files', false)
-  .option('--debug', 'Verbose logging', false)
+  .option('-v, --verbose', 'Verbose logging', false)
+  .option('--debug', 'Alias for --verbose', false)
   .option('--context <n>', 'Requested context size for the model (tokens)', (v)=>parseInt(v,10))
   .option('--fast', 'Faster, smaller generations', false)
   .option('--agent', 'Use tool-calling agent (two-pass: plan → tests)', false)
+  .option('--max-tool-calls <n>', 'Maximum tool invocations per chunk when using --agent (default: 40)', (v)=>parseInt(v,10))
   .action(async (modelArg, projectPathArg, opts, cmd) => {
     const projectRoot = path.resolve(projectPathArg);
     const modelSpec = modelArg;
-    const debug = !!opts.debug;
+    const verbose = Boolean(opts.verbose || opts.debug);
+    const debug = verbose;
+    const parsedMaxToolCalls = Number(opts.maxToolCalls);
+    const maxToolCalls = Number.isFinite(parsedMaxToolCalls) && parsedMaxToolCalls > 0
+      ? Math.floor(parsedMaxToolCalls)
+      : 40;
 
     const spin = ora({ spinner: 'dots' });
 
@@ -407,6 +414,7 @@ program
         outDir: testSetup.outputDir,
         force: opts.force,
         debug,
+        maxToolCalls,
         onProgress: commonProgress,
         renderer: testSetup.renderer,
         framework: testSetup.framework,

--- a/src/generateAgent.ts
+++ b/src/generateAgent.ts
@@ -17,6 +17,7 @@ export async function generateWithAgent(
     outDir: string;
     force: boolean;
     debug?: boolean;
+    maxToolCalls?: number;
     renderer: 'rtl-web' | 'rtl-native' | 'none';
     framework: 'jest' | 'vitest';
     scan: ScanResult;
@@ -48,7 +49,7 @@ export async function generateWithAgent(
         agentResult = await runAgent(model, planPrompt, {
           projectRoot: opts.projectRoot,
           scan: opts.scan,
-          maxSteps: 40,
+          maxSteps: opts.maxToolCalls ?? 40,
           onTool: ({ tool, args }) => {
             const detail = (args?.relPath || args?.identifier || args?.component || '');
             opts.onProgress?.({ type: 'tool', file: item.rel, chunkId: chunk.id, message: `${tool} ${detail}` });


### PR DESCRIPTION
## Summary
- add a `--max-tool-calls` CLI option to control the agent tool invocation limit while keeping the previous default
- introduce a `--verbose` flag (with `--debug` as an alias) and clarify the model argument description
- document the new options and note that models are not limited to GGUF files in the README

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68de273f19148328a42621a07b3857a4